### PR TITLE
Chart defaults are now C' and P' only.

### DIFF
--- a/R/plot_code.R
+++ b/R/plot_code.R
@@ -43,7 +43,6 @@ plot_auto_SPC <- function(df,
                           override_y_lim = NULL,
                           override_annotation_dist = 10,
                           override_annotation_dist_P = 25,
-                          prime_chart_volume = 1500,
                           date_break = NULL,
                           r1_col = "orange",
                           r2_col = "steelblue3"
@@ -61,11 +60,9 @@ plot_auto_SPC <- function(df,
   #decide whether the chart is C or P depending on data format if not specified 
   if(is.null(chartType)){
     if(all(c("x", "y") %in% colnames(df))){
-      #rule of thumb for when to convert use a prime chart
-      chartType <- dplyr::if_else(max(df$y) > prime_chart_volume,"C'","C")
+      chartType <- "C'"
     }else if(all(c("x", "n", "b") %in% colnames(df))){
-      #rule of thumb for when to convert use a prime chart
-      chartType <- dplyr::if_else(max(df$n) > prime_chart_volume,"P'","P")
+      chartType <- "P'"
     }else{
       print("The data you have input is not in the correct format. For C charts, data must contain at least columns 'x' and 'y'. For P charts data must contain at least 'x', 'n' and 'b' columns.")
     }

--- a/man/plot_auto_SPC.Rd
+++ b/man/plot_auto_SPC.Rd
@@ -21,7 +21,6 @@ plot_auto_SPC(
   override_y_lim = NULL,
   override_annotation_dist = 10,
   override_annotation_dist_P = 25,
-  prime_chart_volume = 1500,
   date_break = NULL,
   r1_col = "orange",
   r2_col = "steelblue3"


### PR DESCRIPTION
I realised that the algorithm should not have any non-disclosed assumptions, so I have removed the lines that decided whether to plot a prime chart or not.  The default is now to plot a prime chart unless specified in the `chartType` argument. 