### PR TITLE
Test nondate x 19 onto bug fix branch

### DIFF
--- a/tests/testthat/test_integer_x.R
+++ b/tests/testthat/test_integer_x.R
@@ -8,7 +8,8 @@ testthat::test_that("plot_auto_SPC does not throw an error with integer x values
                               70, 68, 43, 76, 98, 108, 79, 92, 84, 76, 69, 88, 83, 101, 81, 
                               72, 89, 90, 81, 82, 68, 82, 84, 93, 79, 87)),
                    row.names = c(NA, -50L),
-                   class = c("tbl_df", "tbl", "data.frame"))
+                   class = c("tbl_df", "tbl", "data.frame")) %>%
+    dplyr::mutate(y = as.integer(y))
   # Expect no error when calling plot_auto_SPC with this data
   expect_error(
     plot_auto_SPC(df1, title = "my title", subtitle = "my subtitle"),

--- a/tests/testthat/test_integer_x.R
+++ b/tests/testthat/test_integer_x.R
@@ -1,0 +1,16 @@
+context("Integer x values")
+
+testthat::test_that("plot_auto_SPC does not throw an error with integer x values", {
+  # Example data
+  df1 <- structure(list(x = 1:50,
+                        y = c(49, 70, 44, 43, 75, 60, 47, 65, 
+                              63, 62, 55, 57, 51, 49, 55, 76, 58, 51, 65, 52, 48, 60, 65, 71, 
+                              70, 68, 43, 76, 98, 108, 79, 92, 84, 76, 69, 88, 83, 101, 81, 
+                              72, 89, 90, 81, 82, 68, 82, 84, 93, 79, 87)),
+                   row.names = c(NA, -50L),
+                   class = c("tbl_df", "tbl", "data.frame"))
+  # Expect no error when calling plot_auto_SPC with this data
+  expect_error(
+    plot_auto_SPC(df1, title = "my title", subtitle = "my subtitle"),
+    NA)
+})


### PR DESCRIPTION
Comment copied from previous pull request:

Also @ImogenConnorHelleur re. the discussion yesterday on the problem of adding scale_x_continuous or similar depending on the scale type - would it work to just handle dates separately, i.e. generate the plot adding everything except the scale (which means ggplot will automatically select a scale) and then if the x type is date, conditionally add a final scale_x_date to the plot object before returning? Thus leaving the ggplot default for e.g. integer x values. Since we return a ggplot object, users can in any case always add a further + scale_x_continuous(...) to the returned plot if they so wish.... I think us returning a plot that uses the ggplot default x scale is not a bad idea...