### PR TITLE
Feature passcols 24

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,4 +23,5 @@ Imports:
     ggplot2 (>= 3.3.3),
     lubridate (>= 1.7.10),
     qicharts2 (>= 0.7.1),
+    rlang (>= 0.4.11),
     scales (>= 1.1.1)

--- a/R/functions.R
+++ b/R/functions.R
@@ -242,3 +242,51 @@ initialise_limits <- function(data, periodMin,
   limits_table <- add_rule_breaks(x = limits_table)
 }
 
+
+#function to rename columns
+rename_columns <- function(df, x, y, n, b) {
+  
+  data_colnames <- colnames(df)
+  
+  x <- rlang::enquo(x)
+  y <- rlang::enquo(y)
+  n <- rlang::enquo(n)
+  b <- rlang::enquo(b)
+  
+  # Rename columns to standard names
+  if(!rlang::quo_is_missing(x)) {
+    if("x" %in% data_colnames) {
+      warning("x is present in the data and specified as an argument.
+The column specified in the argument x will be used.")
+    }
+    df <- df %>% dplyr::rename(x = !!x)
+  }
+  
+  if(!rlang::quo_is_missing(y)) {
+    if("y" %in% data_colnames) {
+      warning("y is present in the data and specified as an argument.
+The column specified in the argument y will be used.")
+    }
+    df <- df %>% dplyr::rename(y = !!y)
+  }
+  
+  if(!rlang::quo_is_missing(n)) {
+    if("n" %in% data_colnames) {
+      warning("n is present in the data and specified as an argument.
+The column specified in the argument n will be used.")
+    }
+    df <- df %>% dplyr::rename(n = !!n)
+  }
+  
+  if(!rlang::quo_is_missing(b)) {
+    if("b" %in% data_colnames) {
+      warning("b is present in the data and specified as an argument.
+The column specified in the argument b will be used.")
+    }
+    df <- df %>% dplyr::rename(b = !!b)
+  }
+  
+  return(df)
+  
+}
+

--- a/R/plot_code.R
+++ b/R/plot_code.R
@@ -60,37 +60,9 @@ plot_auto_SPC <- function(df,
                           r2_col = "steelblue3"
 ) { 
   
-  data_colnames <- colnames(df)
-
-  # Rename columns to standard names
-  if(!missing(x)) {
-    if("x" %in% data_colnames) {
-      warning("x is present in the data and specified as an argument.
-The column specified in the argument x will be used.")
-    }
-    df <- df %>% dplyr::rename(x = {{ x }})
-  }
-  if(!missing(y)) {
-    if("y" %in% data_colnames) {
-      warning("y is present in the data and specified as an argument.
-The column specified in the argument y will be used.")
-    }
-    df <- df %>% dplyr::rename(y = {{ y }})
-  }
-  if(!missing(n)) {
-    if("n" %in% data_colnames) {
-      warning("n is present in the data and specified as an argument.
-The column specified in the argument n will be used.")
-    }
-    df <- df %>% dplyr::rename(n = {{ n }})
-  }
-  if(!missing(b)) {
-    if("b" %in% data_colnames) {
-      warning("b is present in the data and specified as an argument.
-The column specified in the argument b will be used.")
-    }
-    df <- df %>% dplyr::rename(b = {{ b }})
-  }
+  #rename columns if passed
+  df <- rename_columns(df = df,
+                       x = {{ x }}, y = {{ y }}, n = {{ n }}, b = {{ b }})
   
   #get title from data
   if(is.null(title)){

--- a/R/plot_code.R
+++ b/R/plot_code.R
@@ -19,6 +19,14 @@
 #' (useful for doing lots of charts at a time) 
 #' @param noRegrets Boolean signifying which version of the algorithm should be used. 
 #' Defines whether limits can change as more data is added or not.
+#' @param x column to use as subgroups on the horizontal axis of the chart
+#' (passed using tidyselect)
+#' @param y column to use as count (vertical axis) for C and C' charts (passed
+#' using tidyselect)
+#' @param n column to use as denominator for P and P' charts (passed using
+#' tidyselect)
+#' @param b column to use as numerator for P and P' charts (passed using
+#' tidyselect)
 #'
 #' @return An SPC ggplot or corresponding data
 #'
@@ -36,6 +44,10 @@ plot_auto_SPC <- function(df,
                           plotChart = T,
                           writeTable = F,
                           noRegrets = T,
+                          x,
+                          y,
+                          n,
+                          b,
                           
                           #overrides for plot aesthetics not detailed in roxygen skeleton
                           override_x_title = NULL,
@@ -47,6 +59,20 @@ plot_auto_SPC <- function(df,
                           r1_col = "orange",
                           r2_col = "steelblue3"
 ) { 
+
+  # Rename columns to standard names
+  if(!missing(x)) {
+    df <- df %>% dplyr::rename(x = {{ x }})
+  }
+  if(!missing(y)) {
+    df <- df %>% dplyr::rename(y = {{ y }})
+  }
+  if(!missing(n)) {
+    df <- df %>% dplyr::rename(n = {{ n }})
+  }
+  if(!missing(b)) {
+    df <- df %>% dplyr::rename(b = {{ b }})
+  }
   
   #get title from data
   if(is.null(title)){

--- a/R/plot_code.R
+++ b/R/plot_code.R
@@ -59,18 +59,36 @@ plot_auto_SPC <- function(df,
                           r1_col = "orange",
                           r2_col = "steelblue3"
 ) { 
+  
+  data_colnames <- colnames(df)
 
   # Rename columns to standard names
   if(!missing(x)) {
+    if("x" %in% data_colnames) {
+      warning("x is present in the data and specified as an argument.
+The column specified in the argument x will be used.")
+    }
     df <- df %>% dplyr::rename(x = {{ x }})
   }
   if(!missing(y)) {
+    if("y" %in% data_colnames) {
+      warning("y is present in the data and specified as an argument.
+The column specified in the argument y will be used.")
+    }
     df <- df %>% dplyr::rename(y = {{ y }})
   }
   if(!missing(n)) {
+    if("n" %in% data_colnames) {
+      warning("n is present in the data and specified as an argument.
+The column specified in the argument n will be used.")
+    }
     df <- df %>% dplyr::rename(n = {{ n }})
   }
   if(!missing(b)) {
+    if("b" %in% data_colnames) {
+      warning("b is present in the data and specified as an argument.
+The column specified in the argument b will be used.")
+    }
     df <- df %>% dplyr::rename(b = {{ b }})
   }
   

--- a/tests/testthat/test_pass_column_names.R
+++ b/tests/testthat/test_pass_column_names.R
@@ -1,0 +1,23 @@
+context("Test passing different column names")
+
+test_data <- readRDS("testdata/test_data.rds")
+
+testthat::test_that("Renaming columns doesn't change the result",{
+  
+  test_data1 <- test_data %>%
+    dplyr::select(x, y)
+  
+  test_data2 <- test_data %>%
+    dplyr::select(month = x, count = y)
+  
+  result1 <- plot_auto_SPC(test_data1,
+                           plotChart = FALSE)
+  
+  result2 <- plot_auto_SPC(test_data2,
+                           x = month,
+                           y = count,
+                           plotChart = FALSE)
+  
+  testthat::expect_equal(result1, result2)
+  
+})


### PR DESCRIPTION
This branch fixes #24. Instead of working all the way through the call stack replacing every instance of code referring to `x` with code that uses ``{{ x }}` (and similar for `y`, `n`, and `b`), I just added some code at the top to rename user-specified columns to these standard names. This is a bit less neat but much less work than the alternative. @ImogenConnorHelleur what do you think?