### PR TITLE
Bug fix line aesthetics 10 45

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -407,3 +407,19 @@ The column specified in the argument b will be used.")
 is_numeric_vector_constant <- function(x) {
   diff(range(x)) < .Machine$double.eps ^ 0.5
 }
+
+
+#helper function to fill in NA values with previous non-NA value
+#used for line aestetics
+fill_NA <- function(x) {
+  which.na <- c(which(!is.na(x)), length(x) + 1)
+  values <- na.omit(x)
+  
+  if (which.na[1] != 1) {
+    which.na <- c(1, which.na)
+    values <- c(values[1], values)
+  }
+  
+  diffs <- diff(which.na)
+  return(rep(values, times = diffs))
+}

--- a/R/plot_code.R
+++ b/R/plot_code.R
@@ -151,6 +151,12 @@ plot_auto_SPC <- function(df,
   ucl_start <- round(df$ucl[1])
   cl_end <- round(df$cl[(nrow(df)-1)])
   
+  #get periods into groups for plotting
+  df <- df %>%
+    dplyr::mutate(periodStart = dplyr::if_else(limitChange == TRUE | is.na(limitChange), dplyr::row_number(), NA_integer_))
+  
+  df$periodStart <- fill_NA(df$periodStart)
+  
   if(plotChart == TRUE){
     
     annotation_dist_fact <- ifelse(chartType == "C" | chartType == "C'", 
@@ -232,12 +238,17 @@ format_SPC <- function(cht, df, r1_col, r2_col, ymin, ymax) {
   point_colours <- c("Rule 1" = r1_col, "Rule 2" = r2_col, "None" = "black", "Excluded from limits calculation" = "grey")
   cht + 
     ggplot2::geom_line(colour = "black", size = 0.5) + 
-    ggplot2::geom_line(data = dplyr::mutate(df, cl = ifelse(periodType == "calculation", cl, NA)), ggplot2::aes(x,cl), size = 0.75, linetype = "solid") +
-    ggplot2::geom_line(data = dplyr::mutate(df, cl = ifelse(periodType == "display", cl, NA)), ggplot2::aes(x,cl), size = 0.75, linetype = "42") +
-    ggplot2::geom_line(data = dplyr::mutate(df, ucl = ifelse(periodType == "calculation", ucl, NA)), ggplot2::aes(x,ucl), size = 0.5, linetype = "solid") +
-    ggplot2::geom_line(data = dplyr::mutate(df, ucl = ifelse(periodType == "display", ucl, NA)), ggplot2::aes(x,ucl), size = 0.5, linetype = "84") +
-    ggplot2::geom_line(data = dplyr::mutate(df, lcl = ifelse(periodType == "calculation", lcl, NA)), ggplot2::aes(x,lcl), size = 0.5, linetype = "solid") +
-    ggplot2::geom_line(data = dplyr::mutate(df, lcl = ifelse(periodType == "display", lcl, NA)), ggplot2::aes(x,lcl), size = 0.5, linetype = "84") +
+    # ggplot2::geom_line(data = dplyr::mutate(df, cl = ifelse(periodType == "calculation", cl, NA)), ggplot2::aes(x,cl), size = 0.75, linetype = "solid") +
+    # ggplot2::geom_line(data = dplyr::mutate(df, cl = ifelse(periodType == "display", cl, NA)), ggplot2::aes(x,cl), size = 0.75, linetype = "42") +
+    # ggplot2::geom_line(data = dplyr::mutate(df, ucl = ifelse(periodType == "calculation", ucl, NA)), ggplot2::aes(x,ucl), size = 0.5, linetype = "solid") +
+    # ggplot2::geom_line(data = dplyr::mutate(df, ucl = ifelse(periodType == "display", ucl, NA)), ggplot2::aes(x,ucl), size = 0.5, linetype = "84") +
+    # ggplot2::geom_line(data = dplyr::mutate(df, lcl = ifelse(periodType == "calculation", lcl, NA)), ggplot2::aes(x,lcl), size = 0.5, linetype = "solid") +
+    # ggplot2::geom_line(data = dplyr::mutate(df, lcl = ifelse(periodType == "display", lcl, NA)), ggplot2::aes(x,lcl), size = 0.5, linetype = "84") +
+    ggplot2::geom_line(data = df, 
+                       ggplot2::aes(x,cl,
+                                    size = periodStart,
+                                    linetype = periodType
+                                    )) +
   
     ggplot2::geom_point(ggplot2::aes(colour = highlight), size = 2) +
     ggplot2::scale_color_manual("Rule triggered*", values = point_colours) + 

--- a/R/plot_code.R
+++ b/R/plot_code.R
@@ -153,9 +153,14 @@ plot_auto_SPC <- function(df,
   
   #get periods into groups for plotting
   df <- df %>%
-    dplyr::mutate(periodStart = dplyr::if_else(limitChange == TRUE | is.na(limitChange), dplyr::row_number(), NA_integer_))
+    dplyr::mutate(periodStart = dplyr::if_else(limitChange == TRUE | is.na(limitChange) | breakPoint == TRUE,
+                                               dplyr::row_number(), 
+                                               NA_integer_))
   
   df$periodStart <- fill_NA(df$periodStart)
+  
+  df <- df %>% 
+    dplyr::mutate(plotPeriod = paste0(periodType, periodStart))
   
   if(plotChart == TRUE){
     
@@ -235,23 +240,42 @@ plot_auto_SPC <- function(df,
 
 
 format_SPC <- function(cht, df, r1_col, r2_col, ymin, ymax) {
-  point_colours <- c("Rule 1" = r1_col, "Rule 2" = r2_col, "None" = "black", "Excluded from limits calculation" = "grey")
+  point_colours <- c("Rule 1" = r1_col, "Rule 2" = r2_col, 
+                     "None" = "black", "Excluded from limits calculation" = "grey")
+  
+  #get the line types for calculation and display periods
+  plot_periods <- df$plotPeriod
+  unique_plot_periods <- unique(plot_periods)
+  num_calculation_periods <- length(grep("calculation", unique_plot_periods))
+  num_display_periods <- length(grep("display", unique_plot_periods))
+  
+  first_display_period <- plot_periods[grep("display", plot_periods)[1]]
+  first_calc_period <- plot_periods[1]
+  
+  linetypes <- c(rep("solid", num_calculation_periods),
+                 rep("42", num_display_periods))
+ 
+  
   cht + 
     ggplot2::geom_line(colour = "black", size = 0.5) + 
-    # ggplot2::geom_line(data = dplyr::mutate(df, cl = ifelse(periodType == "calculation", cl, NA)), ggplot2::aes(x,cl), size = 0.75, linetype = "solid") +
-    # ggplot2::geom_line(data = dplyr::mutate(df, cl = ifelse(periodType == "display", cl, NA)), ggplot2::aes(x,cl), size = 0.75, linetype = "42") +
-    # ggplot2::geom_line(data = dplyr::mutate(df, ucl = ifelse(periodType == "calculation", ucl, NA)), ggplot2::aes(x,ucl), size = 0.5, linetype = "solid") +
-    # ggplot2::geom_line(data = dplyr::mutate(df, ucl = ifelse(periodType == "display", ucl, NA)), ggplot2::aes(x,ucl), size = 0.5, linetype = "84") +
-    # ggplot2::geom_line(data = dplyr::mutate(df, lcl = ifelse(periodType == "calculation", lcl, NA)), ggplot2::aes(x,lcl), size = 0.5, linetype = "solid") +
-    # ggplot2::geom_line(data = dplyr::mutate(df, lcl = ifelse(periodType == "display", lcl, NA)), ggplot2::aes(x,lcl), size = 0.5, linetype = "84") +
     ggplot2::geom_line(data = df, 
                        ggplot2::aes(x,cl,
-                                    size = periodStart,
-                                    linetype = periodType
-                                    )) +
-  
+                                    linetype = plotPeriod),
+                       size = 0.75) +
+    ggplot2::geom_line(data = df, 
+                       ggplot2::aes(x,lcl,
+                                    linetype = plotPeriod),
+                       size = 0.5) +
+    ggplot2::geom_line(data = df, 
+                       ggplot2::aes(x,ucl,
+                                    linetype = plotPeriod),
+                       size = 0.5) +
     ggplot2::geom_point(ggplot2::aes(colour = highlight), size = 2) +
     ggplot2::scale_color_manual("Rule triggered*", values = point_colours) + 
+    ggplot2::scale_linetype_manual("Period Type",
+                                   labels = c("Calculation", "Display"),
+                                   values = linetypes,
+                                   breaks = c(first_calc_period, first_display_period)) +
     ggplot2::theme(panel.grid.major.y = ggplot2::element_blank(),
                    panel.grid.major.x = ggplot2::element_line(colour = "grey80"),
           panel.grid.minor = ggplot2::element_blank(),


### PR DESCRIPTION
Finally fixed #10 and #45 

Now adds new column called `plotPeriod` which is distinct for each separate period in the data based on whether it's  calculation or display and where the period starts (e.g. calculation1, display26, calculation43, display64...). It's necessary to have distinct groups for each period otherwise ggplot will join up all of the calculation periods when we want a clean break between them. 

To avoid having several elements in the legend, I get the number of distinct calculation and display periods and repeat the desired line types (lines 246 to 256 in the `plot_code.R` file).  I use the `breaks` argument in `scale_linetype_manual` to only show the elements relating to the first calculation period and first display period because otherwise we'd just have the same elements repeated for however many periods we have.