### PR TITLE
Converts Inf and NaN values to NA if n is zero.

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -37,7 +37,8 @@ create_SPC_auto_limits_table <- function(data,
   if(chartType == "P" | chartType == "P'"){
     data <- data %>% 
       dplyr::mutate(y_numerator = y) %>%
-      dplyr::mutate(y = y * 100 / n)
+      dplyr::mutate(y = y * 100 / n) %>%
+      dplyr::mutate(y = dplyr::if_else(is.nan(y) | is.infinite(y), as.numeric(NA), y))
   }
   
   #set counter to zero
@@ -155,7 +156,10 @@ create_SPC_auto_limits_table <- function(data,
 
     #add a column to show where the breakpoints are
     limits_table <- limits_table %>%
-      dplyr::mutate(breakPoint = ifelse(cl == dplyr::lag(cl), FALSE, TRUE))
+      dplyr::mutate(breakPoint = ifelse(cl == dplyr::lag(cl), FALSE, TRUE)) %>%
+      dplyr::mutate(ucl = dplyr::if_else(is.na(y), as.numeric(NA), ucl)) %>%
+      dplyr::mutate(lcl = dplyr::if_else(is.na(y), as.numeric(NA), lcl)) %>%
+      dplyr::mutate(cl = dplyr::if_else(is.na(y), as.numeric(NA), cl))
 
     limits_table
     

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -158,8 +158,7 @@ create_SPC_auto_limits_table <- function(data,
     limits_table <- limits_table %>%
       dplyr::mutate(breakPoint = ifelse(cl == dplyr::lag(cl), FALSE, TRUE)) %>%
       dplyr::mutate(ucl = dplyr::if_else(is.na(y), as.numeric(NA), ucl)) %>%
-      dplyr::mutate(lcl = dplyr::if_else(is.na(y), as.numeric(NA), lcl)) %>%
-      dplyr::mutate(cl = dplyr::if_else(is.na(y), as.numeric(NA), cl))
+      dplyr::mutate(lcl = dplyr::if_else(is.na(y), as.numeric(NA), lcl)) 
 
     limits_table
     

--- a/tests/testthat/test_zero_attendances.R
+++ b/tests/testthat/test_zero_attendances.R
@@ -1,0 +1,61 @@
+#load in test data
+#zeros in n column only
+test_data1 <- data.frame(x = 1:50, 
+                         y = c(53, 53, 53, 45, 49, 54, 48, 48,
+                               55, 52, 52, 50, 45, 52, 49, 51, 
+                               52, 50, 54, 47, 27, 25, 23,
+                               28, 22, 23, 25, 27,
+                               26, 28, 20, 22, 
+                               24, 21, 29, 28, 28, 21, 20, 22, 
+                               22, 25, 27, 29, 21, 27, 20, 23, 
+                               22, 22), 
+                         n = c(197, 196, 203, 201, 201, 200, 195, 
+                               197, 200, 202, 203, 199, 197, 201, 
+                               205, 201, 199, 201, 200, 192, 201, 
+                               202, 203,
+                               0, 0, 0, 0, 0, 
+                               200, 197, 201, 205, 198, 194, 200, 
+                               201, 201, 195, 200, 191, 194, 206, 
+                               205, 199, 202, 195, 199, 197, 201, 
+                               198))
+
+#zeros in both y and n
+test_data2 <- data.frame(x = 1:50, 
+                         y = c(53, 53, 53, 45, 49, 54, 48, 48,
+                               55, 52, 52, 50, 45, 52, 49, 51, 
+                               52, 50, 54, 47, 27, 25, 23,
+                               0, 0, 0, 0, 0,
+                               26, 28, 20, 22, 
+                               24, 21, 29, 28, 28, 21, 20, 22, 
+                               22, 25, 27, 29, 21, 27, 20, 23, 
+                               22, 22), 
+                         n = c(197, 196, 203, 201, 201, 200, 195, 
+                               197, 200, 202, 203, 199, 197, 201, 
+                               205, 201, 199, 201, 200, 192, 201, 
+                               202, 203,
+                               0, 0, 0, 0, 0, 
+                               200, 197, 201, 205, 198, 194, 200, 
+                               201, 201, 195, 200, 191, 194, 206, 
+                               205, 199, 202, 195, 199, 197, 201, 
+                               198))
+                                                                                                 
+
+test_that("P charts with zero attendances error handle",{
+  
+  result1 <- plot_auto_SPC(test_data1, chartType = "P'", plotChart = FALSE, periodMin = 21) %>%
+    dplyr::select(x, y, n, y_numerator, ucl, lcl, cl)
+  
+  result2 <- plot_auto_SPC(test_data2, chartType = "P'", plotChart = FALSE, periodMin = 21) %>%
+    dplyr::select(x, y, n, y_numerator, ucl, lcl, cl)
+  
+  testthat::expect_equal(all(is.na(result1$y[24:28])), TRUE)
+  testthat::expect_equal(all(is.na(result1$ucl[24:28])), TRUE)
+  testthat::expect_equal(all(is.na(result1$lcl[24:28])), TRUE)
+  testthat::expect_equal(all(is.na(result1$cl[24:28])), TRUE)
+  
+  testthat::expect_equal(all(is.na(result2$y[24:28])), TRUE)
+  testthat::expect_equal(all(is.na(result2$ucl[24:28])), TRUE)
+  testthat::expect_equal(all(is.na(result2$lcl[24:28])), TRUE)
+  testthat::expect_equal(all(is.na(result2$cl[24:28])), TRUE)
+  
+})

--- a/tests/testthat/test_zero_attendances.R
+++ b/tests/testthat/test_zero_attendances.R
@@ -38,6 +38,27 @@ test_data2 <- data.frame(x = 1:50,
                                201, 201, 195, 200, 191, 194, 206, 
                                205, 199, 202, 195, 199, 197, 201, 
                                198))
+
+
+#zeros in both y and n in calc period
+test_data3 <- data.frame(x = 1:50, 
+                         y = c(53, 53, 53, 45, 49, 54, 48, 48,
+                               55, 0, 0, 51, 53, 52, 49, 51, 
+                               52, 50, 54, 47, 27, 25, 23,
+                               25, 27, 29, 21, 27,
+                               26, 28, 20, 22, 
+                               24, 21, 29, 28, 28, 21, 20, 22, 
+                               22, 25, 27, 29, 21, 27, 20, 23, 
+                               22, 22), 
+                         n = c(197, 196, 203, 201, 201, 200, 195, 
+                               197, 200, 0, 0, 0, 0, 201, 
+                               205, 201, 199, 201, 200, 192, 201, 
+                               202, 203,
+                               201, 195, 200, 191, 194, 
+                               200, 197, 201, 205, 198, 194, 200, 
+                               201, 201, 195, 200, 191, 194, 206, 
+                               205, 199, 202, 195, 199, 197, 201, 
+                               198))
                                                                                                  
 
 test_that("P charts with zero attendances error handle",{
@@ -48,14 +69,22 @@ test_that("P charts with zero attendances error handle",{
   result2 <- plot_auto_SPC(test_data2, chartType = "P'", plotChart = FALSE, periodMin = 21) %>%
     dplyr::select(x, y, n, y_numerator, ucl, lcl, cl)
   
+  result3 <- plot_auto_SPC(test_data3, chartType = "P'", plotChart = FALSE, periodMin = 21) %>%
+    dplyr::select(x, y, n, y_numerator, ucl, lcl, cl)
+  
   testthat::expect_equal(all(is.na(result1$y[24:28])), TRUE)
   testthat::expect_equal(all(is.na(result1$ucl[24:28])), TRUE)
   testthat::expect_equal(all(is.na(result1$lcl[24:28])), TRUE)
-  testthat::expect_equal(all(is.na(result1$cl[24:28])), TRUE)
+  testthat::expect_equal(all(!is.na(result1$cl[24:28])), TRUE)
   
   testthat::expect_equal(all(is.na(result2$y[24:28])), TRUE)
   testthat::expect_equal(all(is.na(result2$ucl[24:28])), TRUE)
   testthat::expect_equal(all(is.na(result2$lcl[24:28])), TRUE)
-  testthat::expect_equal(all(is.na(result2$cl[24:28])), TRUE)
+  testthat::expect_equal(all(!is.na(result2$cl[24:28])), TRUE)
+  
+  testthat::expect_equal(all(is.na(result3$y[10:13])), TRUE)
+  testthat::expect_equal(all(is.na(result3$ucl[10:13])), TRUE)
+  testthat::expect_equal(all(is.na(result3$lcl[10:13])), TRUE)
+  testthat::expect_equal(all(!is.na(result3$cl[10:13])), TRUE)
   
 })


### PR DESCRIPTION
For P charts, currently an error is thrown if the n value is zero as it causes the y value to be wither NaN (0/0) or Inf (y/0).

This solution forces any NaN or Inf values in the calculated y column for P charts to be set to NA as well as the limits. 

This is the plotted output of one of the tests:
![image](https://user-images.githubusercontent.com/31736674/223185214-d634ab63-44e2-4693-86a5-7d85841edfcb.png)

This is what qichart2 does:
![image](https://user-images.githubusercontent.com/31736674/223185339-be53aed6-bb86-48de-8ab7-03e2684481b9.png)

Fixes #78 