### PR TITLE
Make the caption reflect the user-defined shift rule threshold

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: autospc
 Title: Automatically Partitioned SPC Charts
-Version: 0.0.0.9042
+Version: 0.0.0.9047
 Authors@R: c(
     person("Thomas", "Woodcock", , "woodcock.thomas@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-4735-4856")),

--- a/R/autospc.R
+++ b/R/autospc.R
@@ -221,8 +221,7 @@ autospc <- function(data,
                     annotation_arrow_curve = 0.3,
                     override_annotation_dist = NULL,
                     override_annotation_dist_P = NULL
-                   
-) { 
+                   ) { 
   
   df_original <- data
   

--- a/R/autospc.R
+++ b/R/autospc.R
@@ -221,7 +221,7 @@ autospc <- function(data,
                     annotation_arrow_curve = 0.3,
                     override_annotation_dist = NULL,
                     override_annotation_dist_P = NULL
-                   ) { 
+) { 
   
   df_original <- data
   
@@ -248,8 +248,8 @@ autospc <- function(data,
   xType               <- preprocessed_vars$xType
   upper_annotation_sf <- preprocessed_vars$upper_annotation_sf
   lower_annotation_sf <- preprocessed_vars$lower_annotation_sf
- 
-   # Get control limits
+  
+  # Get control limits
   data <- create_SPC_auto_limits_table(
     data,
     chart_type = chart_type, 

--- a/R/autospc.R
+++ b/R/autospc.R
@@ -176,7 +176,7 @@ autospc <- function(data,
                     ## Algorithm Parameters
                     period_min = 21,
                     baseline_length = NULL,
-                    shift_rule_threshold = 8,
+                    shift_rule_threshold = 8L,
                     baseline_only = FALSE,
                     establish_every_shift = FALSE,
                     no_regrets = TRUE,
@@ -221,6 +221,7 @@ autospc <- function(data,
                     annotation_arrow_curve = 0.3,
                     override_annotation_dist = NULL,
                     override_annotation_dist_P = NULL
+                   
 ) { 
   
   df_original <- data
@@ -336,6 +337,7 @@ autospc <- function(data,
         df = data,
         p_mr = p_mr,
         chart_type = chart_type,
+        shift_rule_threshold = shift_rule_threshold,
         xType = xType,
         start_x = start_x,
         end_x = end_x,

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -27,7 +27,8 @@ create_spc_plot <- function(df,
                             show_mr = TRUE,
                             x_break = NULL,
                             x_date_format = "%Y-%m-%d",
-                            split_rows = NULL) {
+                            split_rows = NULL,
+                            shift_rule_threshold = 8L) {
   
   df_long <- df %>%
     tidyr::pivot_longer(cols = c(y, cl, ucl, lcl),
@@ -49,10 +50,14 @@ create_spc_plot <- function(df,
   if(use_caption) {
     caption <- paste(chart_type,
                      "Shewhart Chart.",
-                     "\n*Shewhart chart rules apply \nRule 1: Any point",
-                     "outside the control limits \nRule 2: Eight or more",
-                     "consecutive points all above, or all below, the centre",
-                     "line")
+                     "\n*Shewhart chart rules apply",
+                     "\nRule 1: Any point outside the control limits", 
+                     paste( 
+                       "\nRule 2:",
+                       word_for_number(shift_rule_threshold),
+                       "or more consecutive points all above, or all below, the centre line"
+                       )
+    )
     rule_title <- "Rule triggered*"
   } else {
     caption <- NULL
@@ -345,3 +350,26 @@ format_x_axis <- function(p,
   return(p)
   
 }
+
+word_for_number <- function(n) {
+  stopifnot(
+    length(n) == 1,
+    is.numeric(n),
+    n == as.integer(n),
+    n > 0
+  )
+  
+  words <- c(
+    "One", "Two", "Three", "Four", "Five",
+    "Six", "Seven", "Eight", "Nine"
+  )
+  
+  if (n >= 1 && n <= 5) {
+    as.character(n)
+  } else if (n >= 6 && n <= 9) {
+    words[n]
+  } else {
+    as.character(n)
+  }
+}
+

--- a/man/autospc.Rd
+++ b/man/autospc.Rd
@@ -12,7 +12,7 @@ autospc(
   chart_type = NULL,
   period_min = 21,
   baseline_length = NULL,
-  shift_rule_threshold = 8,
+  shift_rule_threshold = 8L,
   baseline_only = FALSE,
   establish_every_shift = FALSE,
   no_regrets = TRUE,

--- a/tests/testthat/test-word-for-number.R
+++ b/tests/testthat/test-word-for-number.R
@@ -1,0 +1,7 @@
+test_that("word_for_number returns readable caption text", {
+  expect_equal(word_for_number(6), "Six")
+  expect_equal(word_for_number(8), "Eight")
+  expect_equal(word_for_number(9), "Nine")
+  expect_equal(word_for_number(10), "10")
+  expect_equal(word_for_number(5), "5")
+})


### PR DESCRIPTION
Fixes hard-coded caption text that always reported "Eight or more consecutive points"
- Makes SPC caption text dynamically reflect the user-specified shift rule threshold