### PR TITLE
Amendment to repair website formatting errors.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: autospc
 Title: Automatically Partitioned SPC Charts
-Version: 0.0.0.9044
+Version: 0.0.0.9046
 Authors@R: c(
     person("Thomas", "Woodcock", , "woodcock.thomas@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-4735-4856")),

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,5 @@
 url: https://horridtom.github.io/autospc/
 template:
+  math-rendering: mathjax
   bootstrap: 5
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,4 +2,3 @@ url: https://horridtom.github.io/autospc/
 template:
   math-rendering: mathjax
   bootstrap: 5
-


### PR DESCRIPTION
Issue: Math is not rendering correctly on vignettes.

The issue is caused by pkgdown using mathml since version 2.1.0, while bookdown uses mathjax, mentioned [here](https://github.com/r-lib/pkgdown/issues/2739#issuecomment-2271872684).
One suggestion from here is to "add `math_method: mathml` in the relevant vignettes under the `html_vignette2` format options"
However, [some issues were flagged in this approach](https://github.com/biocro/biocro/pull/193#issue-3034671150) and instead suggested updating the pkgdown.yml to include `math-rendering: mathjax`

This appears to resolve the issue.